### PR TITLE
Add cases sitemap coverage

### DIFF
--- a/src/pages/sitemap-cases.xml.ts
+++ b/src/pages/sitemap-cases.xml.ts
@@ -1,0 +1,37 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async () => {
+	const cases = await getCollection("cases");
+
+	// Generate the sitemap
+	const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+        <loc>${new URL("/cases", import.meta.env.SITE).href}</loc>
+        <lastmod>${new Date().toISOString()}</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>1.0</priority>
+      </url>
+
+      ${cases
+				.map(
+					(post) => `
+        <url>
+          <loc>${new URL(`/cases/${post.slug}`, import.meta.env.SITE).href}</loc>
+          <lastmod>${post.data.pubDate.toISOString()}</lastmod>
+        <changefreq>daily</changefreq>
+          <priority>1.0</priority>
+        </url>
+      `,
+				)
+				.join("")}
+    </urlset>
+  `;
+
+	return new Response(sitemap, {
+		headers: {
+			"Content-Type": "application/xml; charset=utf-8",
+		},
+	});
+};

--- a/src/pages/sitemap-index.xml.ts
+++ b/src/pages/sitemap-index.xml.ts
@@ -13,6 +13,10 @@ export const GET: APIRoute = async () => {
     <lastmod>${new Date().toISOString()}</lastmod>
   </sitemap>
   <sitemap>
+    <loc>${new URL("/sitemap-cases.xml", import.meta.env.SITE).href}</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+  </sitemap>
+  <sitemap>
     <loc>${new URL("/sitemap-resources.xml", import.meta.env.SITE).href}</loc>
     <lastmod>${new Date().toISOString()}</lastmod>
   </sitemap>

--- a/src/pages/sitemap-main.xml.ts
+++ b/src/pages/sitemap-main.xml.ts
@@ -26,6 +26,13 @@ export const GET: APIRoute = async () => {
       </url>
 
       <url>
+        <loc>${new URL("/cases", import.meta.env.SITE).href}</loc>
+        <lastmod>${new Date().toISOString()}</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>1.0</priority>
+      </url>
+
+      <url>
         <loc>${new URL("/ships", import.meta.env.SITE).href}</loc>
         <lastmod>${new Date().toISOString()}</lastmod>
         <changefreq>daily</changefreq>


### PR DESCRIPTION
## Summary
- add a cases sitemap endpoint that lists the cases collection entries and the /cases index with pubDate-based lastmod values
- register the new cases sitemap in the sitemap index alongside other section sitemaps
- surface the /cases section in the main sitemap for top-level coverage

## Testing
- npm run lint
- npm run build (emits existing warnings about missing content directories and inline script hints)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69578ff4dd7083209d0b8489f60bb741)